### PR TITLE
Added api name to the page title

### DIFF
--- a/src/templates/v1/base.html.twig
+++ b/src/templates/v1/base.html.twig
@@ -25,7 +25,7 @@
     {% block styles %}{% endblock styles %}
     {% block head %}
         {% block seo %}
-            <title>{% block doc_title %}{{ get_config('platform.name') }}{% endblock doc_title %}</title>
+            <title>{% block doc_title %}{% if api is defined %}{{ api }} - {% endif %}{{ get_config('platform.name') }}{% endblock doc_title %}</title>
             <meta name="description" content="Php Simple Fast & Secure">
         {% endblock seo %}
     {% endblock head %}

--- a/src/templates/v2/base.html.twig
+++ b/src/templates/v2/base.html.twig
@@ -19,7 +19,7 @@
     {% block styles %}{% endblock styles %}
     {% block head %}
         {% block seo %}
-            <title>{% block doc_title %}{{ get_config('platform.name') }}{% endblock doc_title %}</title>
+            <title>{% block doc_title %}{% if api is defined %}{{ api }} - {% endif %}{{ get_config('platform.name') }}{% endblock doc_title %}</title>
             <meta name="description" content="Php Simple Fast & Secure">
         {% endblock seo %}
     {% endblock head %}


### PR DESCRIPTION
It was a requirement to add a configuration for the page title to not be the url (`platform.name`). Now it will also add the API name of the model selected in the page title, making it easier to differentiate multiple tabs of PSFS.