### PR TITLE
Add method to override language of X-API-LANG header.

### DIFF
--- a/src/base/Request.php
+++ b/src/base/Request.php
@@ -143,6 +143,15 @@ class Request
         return $header ?: $default;
     }
 
+	/**
+	 * @param string $language
+	 * @return void
+	 */
+	public static function setLanguageHeader(string $language)
+	{
+		self::getInstance()->header['X-API-LANG'] = $language;
+	}
+
     /**
      * Método que devuelve la url solicitada
      * @return string|null


### PR DESCRIPTION
The existing localization behaviour gives priority to the X-API-LANG request header to extract the locale (see `extractLocale` in i18nHelper). But we need a way to override this behaviour in specific cases (for example when generating a report with a given customer language). 

The proposal solution adds a method to just override the request language without breaking existing behaviour, so we can use it like this:
`Request::setLanguageHeader($language);
 PDFService::changeLocale($customer->getCode(), $language);`

Maybe this is not the cleanest solution, but changing I18nHelper is challenging without breaking existing behaviour and affecting entire platform.